### PR TITLE
fix: publish compiled enigma release artifacts

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,11 +9,20 @@ jobs:
   checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.0.0
+        with:
+          python-version: "3.14"
       - name: Install system dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential cmake
+      - name: Install Python checks
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install ruff==0.15.17 pip-audit==2.10.1
       - name: Run checks
         run: ./check.sh
       - name: Audit Python dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.0.0
         with:
           python-version: "3.14"
 
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y build-essential cmake
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Run ShellCheck
         run: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,7 +9,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           release-type: python
           package-name: enigma-v300

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,17 +13,46 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.0.0
         with:
           python-version: "3.14"
 
-      - name: Build package
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake g++-10
+
+      - name: Build Python package
         run: |
           python -m pip install --upgrade pip build
           python -m build
+
+      - name: Build C and C++ release binaries
+        run: |
+          set -euo pipefail
+
+          cmake -S c -B c/build -DCMAKE_BUILD_TYPE=Release
+          cmake --build c/build --config Release
+          ctest --test-dir c/build --output-on-failure
+
+          cmake -S cpp -B cpp/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++-10
+          cmake --build cpp/build --config Release
+
+      - name: Package compiled artifacts
+        run: |
+          set -euo pipefail
+          mkdir -p dist/native
+          cp c/build/enigma_v300_pure_c dist/native/
+          cp cpp/build/enigma_v300_pure_cpp dist/native/
+          tar -czf "dist/enigma-v300-c-linux-amd64-${GITHUB_REF_NAME}.tar.gz" -C dist/native enigma_v300_pure_c
+          tar -czf "dist/enigma-v300-cpp-linux-amd64-${GITHUB_REF_NAME}.tar.gz" -C dist/native enigma_v300_pure_cpp
+          (
+            cd dist
+            sha256sum *.tar.gz *.whl 2>/dev/null | sort -k 2 > SHA256SUMS.txt
+          )
 
       - name: Extract release notes from CHANGELOG
         run: |
@@ -38,8 +67,16 @@ jobs:
           cat release_notes.md
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
-        with:
-          name: ${{ github.event.repository.name }} ${{ github.ref_name }}
-          body_path: release_notes.md
-          files: dist/*
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="${{ github.ref_name }}"
+          if gh release view "$tag" >/dev/null 2>&1; then
+            gh release upload "$tag" dist/* --clobber
+          else
+            gh release create "$tag" dist/* \
+              --title "${{ github.event.repository.name }} $tag" \
+              --notes-file release_notes.md \
+              --verify-tag
+          fi

--- a/.github/workflows/test-all-implementations.yml
+++ b/.github/workflows/test-all-implementations.yml
@@ -12,8 +12,8 @@ jobs:
     name: Test Python Functional Implementation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.0.0
         with:
           python-version: "3.14"
       - name: Test NetTool key generation
@@ -31,8 +31,8 @@ jobs:
     name: Test Python Class-Based Implementation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.0.0
         with:
           python-version: "3.14"
       - name: Test NetTool key generation
@@ -50,7 +50,7 @@ jobs:
     name: Test C Implementation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install build tools
         run: |
           sudo apt-get update
@@ -79,7 +79,7 @@ jobs:
     name: Test C++ Implementation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install build tools
         run: |
           sudo apt-get update
@@ -105,8 +105,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test-python-functions, test-python-classes, test-c-implementation, test-cpp-implementation]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.0.0
         with:
           python-version: "3.14"
       - name: Install build tools

--- a/check.sh
+++ b/check.sh
@@ -2,5 +2,5 @@
 set -euo pipefail
 cd "$(dirname "$0")"
 
+ruff format --check .
 ruff check .
-black --check .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,18 @@ version = "3.0.2"
 description = "Automation tooling for enigma-v300."
 readme = "README.md"
 requires-python = ">=3.14"
-license = { file = "LICENSE" }
+license = "MIT"
+license-files = ["LICENSE"]
 authors = [
   { name = "Kris Armstrong" }
 ]
 dependencies = []
+
+[tool.setuptools]
+py-modules = ["enigma_v300_classes", "enigma_v300_functions"]
+
+[tool.setuptools.package-dir]
+"" = "python"
 
 [project.optional-dependencies]
 dev = [
@@ -30,7 +37,7 @@ testpaths = ["python/tests"]
 
 [tool.ruff]
 line-length = 100
-target-version = "py311"
+target-version = "py314"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "N", "UP", "B", "S", "RUF"]
@@ -38,4 +45,4 @@ ignore = ["S101"]
 
 [tool.black]
 line-length = 100
-target-version = ["py311"]
+target-version = ["py314"]

--- a/python/enigma_v300_classes.py
+++ b/python/enigma_v300_classes.py
@@ -17,6 +17,7 @@ import sys
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
 from pathlib import Path
+from typing import ClassVar
 
 
 def _find_pyproject(start: Path) -> Path | None:
@@ -75,7 +76,24 @@ class EnigmaC:
 
     SOFTWARE_VERSION: str = "3.0.0"
     SERIAL_NUMBER_SIZE_ENIGMAC: int = 10
-    ENIGMA_C_ROTOR: list[int] = [5, 4, 14, 11, 1, 8, 10, 13, 7, 3, 15, 0, 2, 12, 9, 6]
+    ENIGMA_C_ROTOR: ClassVar[list[int]] = [
+        5,
+        4,
+        14,
+        11,
+        1,
+        8,
+        10,
+        13,
+        7,
+        3,
+        15,
+        0,
+        2,
+        12,
+        9,
+        6,
+    ]
 
     def encrypt(self, input_key: str) -> str:
         """Encrypt the input key using EnigmaC cipher.
@@ -166,8 +184,8 @@ class Enigma2C:
     PRODUCT_LOCATION: int = CHECK_SUM_SIZE
     OPTION_LOCATION: int = CHECK_SUM_SIZE + PRODUCT_CODE_SIZE + SERIAL_NUMBER_SIZE_ENIGMA2
     MAX_CHECK_SUM: int = 26000
-    ENIGMA2_E_ROTOR_10: list[int] = [5, 4, 1, 8, 7, 3, 0, 2, 9, 6]
-    ENIGMA2_E_ROTOR_26: list[int] = [
+    ENIGMA2_E_ROTOR_10: ClassVar[list[int]] = [5, 4, 1, 8, 7, 3, 0, 2, 9, 6]
+    ENIGMA2_E_ROTOR_26: ClassVar[list[int]] = [
         16,
         8,
         25,
@@ -195,8 +213,8 @@ class Enigma2C:
         20,
         13,
     ]
-    ENIGMA2_D_ROTOR_10: list[int] = [6, 2, 7, 5, 1, 0, 9, 4, 3, 8]
-    ENIGMA2_D_ROTOR_26: list[int] = [
+    ENIGMA2_D_ROTOR_10: ClassVar[list[int]] = [6, 2, 7, 5, 1, 0, 9, 4, 3, 8]
+    ENIGMA2_D_ROTOR_26: ClassVar[list[int]] = [
         17,
         9,
         8,
@@ -320,7 +338,7 @@ class EnigmaMenu:
 
     SOFTWARE_VERSION: str = "3.0.0"
 
-    PRODUCT_TABLE: list[dict[str, str]] = [
+    PRODUCT_TABLE: ClassVar[list[dict[str, str]]] = [
         {"code": "3001", "abbr": "NTs2", "name": "NetTool Series II"},
         {"code": "7001", "abbr": "LRPro", "name": "LinkRunner Pro Duo"},
         {"code": "6963", "abbr": "Escope/MSv2", "name": "EtherScope/MetroScope"},
@@ -330,7 +348,7 @@ class EnigmaMenu:
         {"code": "1895", "abbr": "iClearSight", "name": "iClearSight Analyzer"},
     ]
 
-    PRODUCT_OPTIONS: dict[str, dict[str, str]] = {
+    PRODUCT_OPTIONS: ClassVar[dict[str, dict[str, str]]] = {
         "6964": {
             "000": "Registered",
             "001": "Wired (Was Copper)",
@@ -639,12 +657,12 @@ class EnigmaMenu:
                 product_name = product["name"]
                 break
         logger.info(f"Product Code: {product_code} -> {product_name}")
-        logger.info(
-            f"SerialNumber: {decrypted_key[self.enigma2_c.SERIAL_LOCATION : self.enigma2_c.SERIAL_LOCATION + self.enigma2_c.SERIAL_NUMBER_SIZE_ENIGMA2]}"
-        )
-        logger.info(
-            f"OptionNumber: {decrypted_key[self.enigma2_c.OPTION_LOCATION : self.enigma2_c.OPTION_LOCATION + self.enigma2_c.OPTION_CODE_SIZE]}"
-        )
+        serial_start = self.enigma2_c.SERIAL_LOCATION
+        serial_end = serial_start + self.enigma2_c.SERIAL_NUMBER_SIZE_ENIGMA2
+        option_start = self.enigma2_c.OPTION_LOCATION
+        option_end = option_start + self.enigma2_c.OPTION_CODE_SIZE
+        logger.info(f"SerialNumber: {decrypted_key[serial_start:serial_end]}")
+        logger.info(f"OptionNumber: {decrypted_key[option_start:option_end]}")
 
     def main_menu(self) -> bool:
         """Display main menu and handle choices.
@@ -719,15 +737,9 @@ def main() -> None:
     )
     parser.add_argument("--verbose", action="store_true", help="Enable debug logging")
     parser.add_argument("--logfile", help="Log to file (rotates at 10MB)")
-    parser.add_argument(
-        "-V", "--version", action="store_true", help="Show version information"
-    )
-    parser.add_argument(
-        "--list-products", action="store_true", help="List known product codes"
-    )
-    parser.add_argument(
-        "--list-options", metavar="CODE", help="List options for a product code"
-    )
+    parser.add_argument("-V", "--version", action="store_true", help="Show version information")
+    parser.add_argument("--list-products", action="store_true", help="List known product codes")
+    parser.add_argument("--list-options", metavar="CODE", help="List options for a product code")
 
     args = parser.parse_args()
     setup_logging(args.verbose, args.logfile)

--- a/python/enigma_v300_functions.py
+++ b/python/enigma_v300_functions.py
@@ -607,12 +607,10 @@ def check_enigma2_option_key(option_key: str) -> None:
             product_name = product["name"]
             break
     logger.info(f"Product Code: {product_code} -> {product_name}")
-    logger.info(
-        f"SerialNumber: {decrypted_key[SERIAL_LOCATION : SERIAL_LOCATION + SERIAL_NUMBER_SIZE_ENIGMA2]}"
-    )
-    logger.info(
-        f"OptionNumber: {decrypted_key[OPTION_LOCATION : OPTION_LOCATION + OPTION_CODE_SIZE]}"
-    )
+    serial_end = SERIAL_LOCATION + SERIAL_NUMBER_SIZE_ENIGMA2
+    option_end = OPTION_LOCATION + OPTION_CODE_SIZE
+    logger.info(f"SerialNumber: {decrypted_key[SERIAL_LOCATION:serial_end]}")
+    logger.info(f"OptionNumber: {decrypted_key[OPTION_LOCATION:option_end]}")
 
 
 def main_menu() -> bool:
@@ -648,8 +646,11 @@ def main_menu() -> bool:
 
 def main() -> None:
     """Main function to handle command-line or interactive mode."""
+    description = (
+        "Fluke option key calculator for NetTool and other products (functional implementation)."
+    )
     parser = argparse.ArgumentParser(
-        description="Fluke option key calculator for NetTool and other products (functional implementation).",
+        description=description,
         epilog="Examples:\n"
         "  python enigma_v300_functions.py -n 0003333016 4 --logfile enigma.log\n"
         "  python enigma_v300_functions.py -e 0000607 7 6963 --verbose",
@@ -688,15 +689,9 @@ def main() -> None:
     )
     parser.add_argument("--verbose", action="store_true", help="Enable debug logging")
     parser.add_argument("--logfile", help="Log to file (rotates at 10MB)")
-    parser.add_argument(
-        "-V", "--version", action="store_true", help="Show version information"
-    )
-    parser.add_argument(
-        "--list-products", action="store_true", help="List known product codes"
-    )
-    parser.add_argument(
-        "--list-options", metavar="CODE", help="List options for a product code"
-    )
+    parser.add_argument("-V", "--version", action="store_true", help="Show version information")
+    parser.add_argument("--list-products", action="store_true", help="List known product codes")
+    parser.add_argument("--list-options", metavar="CODE", help="List options for a product code")
 
     args = parser.parse_args()
     setup_logging(args.verbose, args.logfile)

--- a/python/tests/test_enigma_v300.py
+++ b/python/tests/test_enigma_v300.py
@@ -3,6 +3,7 @@
 
 import sys
 from pathlib import Path
+from typing import ClassVar
 
 import pytest
 
@@ -10,27 +11,27 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
 
 from enigma_v300_functions import (
-    SOFTWARE_VERSION,
-    PRODUCT_TABLE,
-    PRODUCT_OPTIONS,
-    PRODUCT_CODE_SIZE,
-    OPTION_CODE_SIZE,
-    SERIAL_NUMBER_SIZE_ENIGMA2,
-    SERIAL_NUMBER_SIZE_ENIGMAC,
     CHECK_SUM_SIZE,
-    KEY_LENGTH,
-    ENIGMA_C_ROTOR,
-    ENIGMA2_E_ROTOR_10,
-    ENIGMA2_E_ROTOR_26,
     ENIGMA2_D_ROTOR_10,
     ENIGMA2_D_ROTOR_26,
-    enigma_c_encrypt,
-    enigma_c_decrypt,
-    enigma_c_check_option_key,
-    enigma2_c_encrypt,
-    enigma2_c_decrypt,
-    enigma2_c_check_option_key,
+    ENIGMA2_E_ROTOR_10,
+    ENIGMA2_E_ROTOR_26,
+    ENIGMA_C_ROTOR,
+    KEY_LENGTH,
+    OPTION_CODE_SIZE,
+    PRODUCT_CODE_SIZE,
+    PRODUCT_OPTIONS,
+    PRODUCT_TABLE,
+    SERIAL_NUMBER_SIZE_ENIGMA2,
+    SERIAL_NUMBER_SIZE_ENIGMAC,
+    SOFTWARE_VERSION,
     __version__,
+    enigma2_c_check_option_key,
+    enigma2_c_decrypt,
+    enigma2_c_encrypt,
+    enigma_c_check_option_key,
+    enigma_c_decrypt,
+    enigma_c_encrypt,
 )
 
 
@@ -116,7 +117,7 @@ class TestProductOptions:
 
     def test_option_codes_are_valid(self):
         """Option codes should be 3-digit strings."""
-        for product_code, options in PRODUCT_OPTIONS.items():
+        for _product_code, options in PRODUCT_OPTIONS.items():
             for option_code in options.keys():
                 assert len(option_code) == 3, f"Invalid option code {option_code}"
                 assert option_code.isdigit(), f"Option code {option_code} not numeric"
@@ -190,7 +191,7 @@ class TestEnigma2CEncryption:
     """Test Enigma2C cipher - verified against V200 reference."""
 
     # Reference test vectors from enigma V200
-    TEST_VECTORS = [
+    TEST_VECTORS: ClassVar[list[tuple[str, int, str, str]]] = [
         # (serial, option, product, expected_key)
         ("1234567", 7, "6963", "9225940719507747"),  # EtherScope opt 7
         ("1234567", 2, "7001", "8944937150971162"),  # LinkRunner Pro opt 2
@@ -223,7 +224,7 @@ class TestEnigma2CEncryption:
 class TestEnigma2CDecryption:
     """Test Enigma2C decryption - verified against V200 reference."""
 
-    DECRYPT_VECTORS = [
+    DECRYPT_VECTORS: ClassVar[list[tuple[str, str, str, str]]] = [
         # (encrypted_key, expected_product, expected_serial, expected_option)
         ("9225940719507747", "6963", "1234567", "007"),
         ("8944937150971162", "7001", "1234567", "002"),


### PR DESCRIPTION
## Summary
- build C and C++ release binaries in the tag release workflow
- attach Linux amd64 native tarballs and SHA256SUMS alongside the Python package
- publish releases with the GitHub CLI instead of the third-party release action
- fix Python package discovery so `python -m build` works in the mixed-language repo
- pin Enigma workflow actions to immutable SHAs and clean up the Python lint/check blockers exposed by CI
- align `check.sh` with Ruff format/lint instead of stale Black formatting

## Linked Issue
Closes #13

## Testing Evidence
```text
python3 - <<'PY' ... yaml.safe_load(...)
workflow yaml ok

git diff --check
<no output>

PATH=/tmp/enigma-release-venv/bin:$PATH ./check.sh
3 files already formatted
All checks passed!

/tmp/enigma-release-venv/bin/python -m pytest -v
40 passed in 0.09s

/tmp/enigma-release-venv/bin/pip-audit --strict .
No known vulnerabilities found

/tmp/enigma-release-venv/bin/python -m build
Successfully built enigma_v300-3.0.2.tar.gz and enigma_v300-3.0.2-py3-none-any.whl

cmake -S c -B c/build -DCMAKE_BUILD_TYPE=Release && cmake --build c/build --config Release && ctest --test-dir c/build --output-on-failure
100% tests passed, 0 tests failed out of 5

cmake -S cpp -B cpp/build -DCMAKE_BUILD_TYPE=Release && cmake --build cpp/build --config Release
[100%] Built target enigma_v300_pure_cpp

release packaging smoke
SHA256SUMS.txt
enigma-v300-c-linux-amd64-vtest.tar.gz
enigma-v300-cpp-linux-amd64-vtest.tar.gz
enigma_v300-3.0.2-py3-none-any.whl
enigma_v300-3.0.2.tar.gz
```

## Security and Release Checklist
- [x] Release workflow builds before publishing artifacts
- [x] Release artifacts include checksums
- [x] Python package metadata avoids accidental mixed-language package discovery
- [x] Workflow uses pinned first-party setup actions and `gh release` for publication
- [x] CI lint/test/security gates pass locally
